### PR TITLE
Fixes the DNS label empty error

### DIFF
--- a/python/eeg2bids.py
+++ b/python/eeg2bids.py
@@ -1,4 +1,6 @@
 # import _thread
+import os
+os.environ['EVENTLET_NO_GREENDNS'] = 'yes'
 import eventlet
 from eventlet import tpool
 import socketio


### PR DESCRIPTION
Found on @christinerogers's laptop. Occasionally the user's network settings can return an empty label for DNS. The eventlet library will throw an exception. The solution is to set an environmental variable 'EVENTLET_NO_GREENDNS' to yes.