### PR TITLE
Add Playwright Electron integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ Lib/
 Include/
 share/
 
+# playwright electron test output
+test-results/
+playwright-report/
+.playwright/
+
 # workflow tools
 .agents
 .claude

--- a/eeg2bids/server.py
+++ b/eeg2bids/server.py
@@ -14,9 +14,11 @@ import json
 
 # The host and port the local Socket.IO service binds to. The service only
 # ever listens on the loopback interface; the connect handler below rejects
-# any client that is not on 127.0.0.1.
+# any client that is not on 127.0.0.1. The port is configurable through
+# EEG2BIDS_BACKEND_PORT (Electron and the integration tests set it) and
+# defaults to 7301 for normal use.
 HOST = '127.0.0.1'
-PORT = 7301
+PORT = int(os.environ.get('EEG2BIDS_BACKEND_PORT') or 7301)
 
 # LORIS credentials of user
 lorisCredentials = {
@@ -281,7 +283,7 @@ def main():
     """
     _watch_owner_process()
     # A port collision needs no handling here: Werkzeug prints an actionable
-    # "Port 7301 is in use by another program" message and exits non-zero.
+    # "Port <PORT> is in use by another program" message and exits non-zero.
     run_simple(HOST, PORT, app, threaded=True)
 
 

--- a/electron/main/backend-service.js
+++ b/electron/main/backend-service.js
@@ -11,7 +11,10 @@ const path = require('path');
 
 const REPO_ROOT = path.join(__dirname, '../..');
 const BACKEND_HOST = '127.0.0.1';
-const BACKEND_PORT = 7301;
+// The backend port is configurable so tests can reserve a free port rather
+// than assuming 7301 is available; normal use defaults to 7301. The same
+// value is propagated to the spawned Python server and to the renderer.
+const BACKEND_PORT = Number(process.env.EEG2BIDS_BACKEND_PORT) || 7301;
 const STDERR_TAIL_LINES = 20;
 const SIGKILL_TIMEOUT_MS = 3000;
 
@@ -106,7 +109,11 @@ const start = async () => {
     // The backend watches this pid and exits when it disappears, so it is
     // never orphaned even when Electron dies without running will-quit
     // (e.g. a terminal Ctrl+C killing the whole foreground process group).
-    env: {...process.env, EEG2BIDS_OWNER_PID: String(process.pid)},
+    env: {
+      ...process.env,
+      EEG2BIDS_OWNER_PID: String(process.pid),
+      EEG2BIDS_BACKEND_PORT: String(BACKEND_PORT),
+    },
   });
   logOutput(child.stdout, 'stdout');
   logOutput(child.stderr, 'stderr');
@@ -184,4 +191,4 @@ const restart = async () => {
   return {restarted: true};
 };
 
-module.exports = {start, stop, restart, getStatus, isRunning};
+module.exports = {start, stop, restart, getStatus, isRunning, BACKEND_PORT};

--- a/electron/main/backend-service.js
+++ b/electron/main/backend-service.js
@@ -17,11 +17,24 @@ const BACKEND_HOST = '127.0.0.1';
 const BACKEND_PORT = Number(process.env.EEG2BIDS_BACKEND_PORT) || 7301;
 const STDERR_TAIL_LINES = 20;
 const SIGKILL_TIMEOUT_MS = 3000;
+// The backend is only 'running' once the port actually accepts connections,
+// not merely when the python child has spawned. Poll until it does. The
+// timeout is generous because the first `uv run` may build the environment.
+const READINESS_POLL_INTERVAL_MS = 250;
+const READINESS_TIMEOUT_MS = 120000;
 
 let child = null;
 let stopping = false;
+let timedOut = false;
 let stderrTail = [];
 let status = {state: 'stopped', error: null};
+
+/**
+ * Resolve after the given delay.
+ * @param {number} ms - milliseconds to wait
+ * @return {Promise<void>} resolves when the timer fires
+ */
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Record the new backend state and push it to every window.
@@ -46,6 +59,15 @@ const getStatus = () => status;
  * @return {boolean} true when a child process exists
  */
 const isRunning = () => child !== null;
+
+/**
+ * The pid of the owned backend process, which (because the child is spawned
+ * detached) is also its process-group id. Tests use this to assert the whole
+ * group is gone after a clean shutdown, without inspecting unrelated
+ * processes.
+ * @return {?number} the owned pid, or null when nothing is owned
+ */
+const getOwnedPid = () => (child ? child.pid : null);
 
 /**
  * Probe whether something already listens on the backend port.
@@ -85,6 +107,40 @@ const logOutput = (stream, name) => {
 };
 
 /**
+ * Wait for the owned backend to actually accept connections, then mark it
+ * running. The port opening — not the child merely spawning — is what
+ * 'running' means. Give up and terminate the group if the port never opens
+ * within the generous startup window; a child that exits or errors first is
+ * handled by its own listeners.
+ * @param {ChildProcess} owned - the child this wait belongs to
+ */
+const waitForReady = async (owned) => {
+  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+  while (child === owned && !stopping) {
+    if (await isPortInUse()) {
+      if (child === owned && !stopping) {
+        setStatus('running');
+      }
+      return;
+    }
+    if (Date.now() >= deadline) {
+      timedOut = true;
+      const message = `the backend did not open ${BACKEND_HOST}:` +
+        `${BACKEND_PORT} within ${READINESS_TIMEOUT_MS / 1000}s of starting.`;
+      console.error(`[backend] ${message}`);
+      setStatus('failed', message);
+      try {
+        process.kill(-owned.pid, 'SIGTERM');
+      } catch (error) {
+        // already gone
+      }
+      return;
+    }
+    await delay(READINESS_POLL_INTERVAL_MS);
+  }
+};
+
+/**
  * Start the backend unless one is already owned or externally running.
  */
 const start = async () => {
@@ -101,6 +157,7 @@ const start = async () => {
   }
   stderrTail = [];
   stopping = false;
+  timedOut = false;
   setStatus('starting');
   child = spawn('uv', ['run', '--frozen', 'python', '-m', 'eeg2bids'], {
     cwd: REPO_ROOT,
@@ -117,7 +174,13 @@ const start = async () => {
   });
   logOutput(child.stdout, 'stdout');
   logOutput(child.stderr, 'stderr');
-  child.on('spawn', () => setStatus('running'));
+  child.on('spawn', () => {
+    console.info(
+        '[backend] python process spawned; waiting for the port to accept ' +
+        'connections',
+    );
+    waitForReady(child);
+  });
   child.on('error', (error) => {
     child = null;
     const message = `could not launch the backend through uv: ` +
@@ -127,6 +190,10 @@ const start = async () => {
   });
   child.on('exit', (code, signal) => {
     child = null;
+    if (timedOut) {
+      // waitForReady already set a clear 'failed' status and killed the group.
+      return;
+    }
     if (stopping) {
       setStatus('stopped');
       return;
@@ -191,4 +258,6 @@ const restart = async () => {
   return {restarted: true};
 };
 
-module.exports = {start, stop, restart, getStatus, isRunning, BACKEND_PORT};
+module.exports = {
+  start, stop, restart, getStatus, isRunning, getOwnedPid, BACKEND_PORT,
+};

--- a/electron/main/index.js
+++ b/electron/main/index.js
@@ -7,6 +7,14 @@ const {
 const {registerIpcHandlers} = require('./ipc');
 const backendService = require('./backend-service');
 
+// Redirect all user data (settings + encrypted credentials) to an isolated
+// directory when asked. Integration tests point this at a temporary dir so
+// they can never read or modify the real user's credentials. This must run
+// before anything reads app.getPath('userData').
+if (process.env.EEG2BIDS_USER_DATA_DIR) {
+  app.setPath('userData', process.env.EEG2BIDS_USER_DATA_DIR);
+}
+
 registerIpcHandlers();
 
 // Renderer content is untrusted: windows may only show our own renderer,

--- a/electron/main/windows.js
+++ b/electron/main/windows.js
@@ -1,6 +1,7 @@
 const {BrowserWindow, nativeImage} = require('electron');
 const path = require('path');
 const url = require('url');
+const {BACKEND_PORT} = require('./backend-service');
 
 const icon = nativeImage.createFromPath(
     path.join(__dirname, '../../public/logo512.png'),
@@ -26,6 +27,10 @@ const webPreferences = {
   contextIsolation: true,
   sandbox: true,
   preload: path.join(__dirname, '../preload/index.js'),
+  // Carry the configured backend port to the sandboxed renderer. The preload
+  // reads it from process.argv and exposes it; the renderer must not assume
+  // the default 7301.
+  additionalArguments: [`--backend-port=${BACKEND_PORT}`],
 };
 
 /**

--- a/electron/preload/index.js
+++ b/electron/preload/index.js
@@ -1,9 +1,17 @@
 const {contextBridge, ipcRenderer, webUtils} = require('electron');
 
+// The main process passes the configured backend port through
+// additionalArguments as "--backend-port=NNNN"; fall back to 7301.
+const backendPortArg = process.argv.find((arg) =>
+  arg.startsWith('--backend-port='));
+const backendPort = backendPortArg ?
+  Number(backendPortArg.split('=')[1]) || 7301 : 7301;
+
 // The only bridge between the renderer and the main process. Every
 // operation goes through a fixed IPC channel and passes plain serializable
 // values; no Electron objects are ever exposed to renderer code.
 contextBridge.exposeInMainWorld('eeg2bids', {
+  getBackendPort: () => backendPort,
   // Electron no longer exposes the native path as File.path. Resolve it in
   // the preload, where webUtils can safely unwrap a renderer File object.
   getPathForFile: (file) => webUtils.getPathForFile(file),

--- a/electron/tests/backend.spec.js
+++ b/electron/tests/backend.spec.js
@@ -1,0 +1,73 @@
+const {test, expect, canConnect, launchElectron} = require('./fixtures');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Generous because the very first `uv run` may build the Python environment;
+// the fail-fast test proves failures do not depend on any timeout.
+const CONNECT_TIMEOUT = 120000;
+
+test.describe('backend', () => {
+  test('starts, opens its port, and the renderer connects', async ({
+    mainWindow, backendPort,
+  }) => {
+    const status = mainWindow.locator('[data-testid="backend-status"]');
+
+    // Renderer Socket.IO connection: the status anchor reaches 'connected'
+    // only when the socket actually connects to the backend.
+    await expect(status).toHaveAttribute(
+        'data-state', 'connected', {timeout: CONNECT_TIMEOUT},
+    );
+
+    // Backend port availability, verified independently of the renderer.
+    expect(await canConnect(backendPort)).toBe(true);
+
+    // The main process considers the backend running (port accepting
+    // connections), not merely spawned.
+    const backend = await mainWindow.evaluate(
+        () => window.eeg2bids.getBackendStatus(),
+    );
+    expect(backend.state).toBe('running');
+  });
+
+  test('a failed backend surfaces immediately, not via timeout', async ({
+    backendPort,
+  }) => {
+    // Point PATH at an empty directory so `uv` cannot be found: the spawn
+    // errors out at once, exercising the fail-fast path rather than a hang.
+    const emptyPath = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'eeg2bids-nopath-'),
+    );
+    const userDataDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'eeg2bids-userdata-'),
+    );
+    const app = await launchElectron({
+      backendPort,
+      userDataDir,
+      env: {PATH: emptyPath},
+    });
+    try {
+      const window = await app.firstWindow();
+      const status = window.locator('[data-testid="backend-status"]');
+
+      // Well under the suite timeout: the failure is reported promptly.
+      await expect(status).toHaveAttribute(
+          'data-state', 'unavailable', {timeout: 30000},
+      );
+
+      const backend = await window.evaluate(
+          () => window.eeg2bids.getBackendStatus(),
+      );
+      expect(backend.state).toBe('failed');
+      // The message is actionable, naming uv rather than a bare timeout.
+      expect(backend.error).toContain('uv');
+
+      // The failed port never came up.
+      expect(await canConnect(backendPort)).toBe(false);
+    } finally {
+      await app.close();
+      fs.rmSync(emptyPath, {recursive: true, force: true});
+      fs.rmSync(userDataDir, {recursive: true, force: true});
+    }
+  });
+});

--- a/electron/tests/backend.spec.js
+++ b/electron/tests/backend.spec.js
@@ -23,11 +23,14 @@ test.describe('backend', () => {
     expect(await canConnect(backendPort)).toBe(true);
 
     // The main process considers the backend running (port accepting
-    // connections), not merely spawned.
-    const backend = await mainWindow.evaluate(
-        () => window.eeg2bids.getBackendStatus(),
-    );
-    expect(backend.state).toBe('running');
+    // connections), not merely spawned. Its readiness poll can lag the
+    // renderer's socket connecting by up to one poll interval, so converge.
+    await expect.poll(async () => {
+      const s = await mainWindow.evaluate(
+          () => window.eeg2bids.getBackendStatus(),
+      );
+      return s.state;
+    }, {timeout: 10000}).toBe('running');
   });
 
   test('a failed backend surfaces immediately, not via timeout', async ({

--- a/electron/tests/bridge.spec.js
+++ b/electron/tests/bridge.spec.js
@@ -1,0 +1,49 @@
+const {test, expect} = require('./fixtures');
+
+// The complete preload bridge contract exposed to the renderer as
+// window.eeg2bids. The exact set of member names is asserted, so adding or
+// removing a bridge method without updating this test fails. (Function arity
+// is not checked: contextBridge wraps every exposed function and does not
+// preserve its declared parameter count.)
+const EXPECTED_API = [
+  'getBackendPort',
+  'getPathForFile',
+  'selectDirectory',
+  'openExternal',
+  'getLorisAuthenticationCredentials',
+  'setLorisAuthenticationCredentials',
+  'removeLorisAuthenticationCredentials',
+  'openSettings',
+  'getBackendStatus',
+  'restartBackend',
+  'onBackendStatusChange',
+];
+
+test('preload exposes exactly the expected bridge API', async ({
+  mainWindow,
+}) => {
+  const api = await mainWindow.evaluate(() => {
+    const bridge = window.eeg2bids;
+    return Object.keys(bridge).map((key) => [key, typeof bridge[key]]);
+  });
+  const names = api.map(([key]) => key);
+
+  // Exact member set, nothing extra and nothing missing.
+  expect(names.sort()).toEqual([...EXPECTED_API].sort());
+
+  // Every member is a function.
+  for (const [key, type] of api) {
+    expect(type, `${key} should be a function`).toBe('function');
+  }
+});
+
+test('getBackendPort returns the configured, isolated port', async ({
+  mainWindow, backendPort,
+}) => {
+  const port = await mainWindow.evaluate(
+      () => window.eeg2bids.getBackendPort(),
+  );
+  expect(port).toBe(backendPort);
+  // The suite must not depend on the fixed development port.
+  expect(port).not.toBe(7301);
+});

--- a/electron/tests/credentials.spec.js
+++ b/electron/tests/credentials.spec.js
@@ -1,0 +1,67 @@
+const {test, expect} = require('./fixtures');
+const fs = require('fs');
+const path = require('path');
+
+// Credential save/read/remove against an isolated userData directory. The
+// real user's credentials can never be reached: app.setPath('userData', ...)
+// is verified to point at the throwaway directory. safeStorage is stubbed at
+// the runtime boundary because this environment has no OS secret service; the
+// test therefore exercises the persistence and isolation logic only and makes
+// no claim that the stored file is securely encrypted. (On headless Linux the
+// real backend may fall back to --password-store=basic, which likewise does
+// NOT provide secure storage.)
+test('saves, reads, and removes credentials in isolation', async ({
+  electronApp, mainWindow, userDataDir,
+}) => {
+  // Isolation guarantee: user data is redirected to the throwaway directory.
+  const resolved = await electronApp.evaluate(
+      ({app}) => app.getPath('userData'),
+  );
+  expect(resolved).toBe(userDataDir);
+
+  // Replace real OS encryption with a reversible marker so the round-trip is
+  // deterministic on any machine. This does not encrypt anything.
+  await electronApp.evaluate(({safeStorage}) => {
+    safeStorage.isEncryptionAvailable = () => true;
+    safeStorage.getSelectedStorageBackend = () => 'basic_text';
+    safeStorage.encryptString = (s) => Buffer.from('stub:' + s, 'utf8');
+    safeStorage.decryptString = (b) =>
+      Buffer.from(b).toString('utf8').replace(/^stub:/, '');
+  });
+
+  const encFile = path.join(userDataDir, 'loris-credentials.enc');
+  expect(fs.existsSync(encFile)).toBe(false);
+
+  await mainWindow.evaluate(() => window.eeg2bids
+      .setLorisAuthenticationCredentials({
+        lorisURL: 'https://loris.example',
+        lorisUsername: 'test-user',
+        lorisPassword: 'test-pass',
+      }));
+
+  // The encrypted file lands only in the isolated directory.
+  expect(fs.existsSync(encFile)).toBe(true);
+
+  const got = await mainWindow.evaluate(
+      () => window.eeg2bids.getLorisAuthenticationCredentials(),
+  );
+  expect(got).toEqual({
+    lorisURL: 'https://loris.example',
+    lorisUsername: 'test-user',
+    lorisPassword: 'test-pass',
+  });
+
+  await mainWindow.evaluate(
+      () => window.eeg2bids.removeLorisAuthenticationCredentials(),
+  );
+  expect(fs.existsSync(encFile)).toBe(false);
+
+  const after = await mainWindow.evaluate(
+      () => window.eeg2bids.getLorisAuthenticationCredentials(),
+  );
+  expect(after).toEqual({
+    lorisURL: '',
+    lorisUsername: '',
+    lorisPassword: '',
+  });
+});

--- a/electron/tests/fixtures.js
+++ b/electron/tests/fixtures.js
@@ -1,0 +1,70 @@
+const {test: base, _electron: electron} = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '../..');
+
+/**
+ * Reserve a currently-free loopback TCP port. The socket is released before
+ * returning, so there is a small window in which the port could be taken by
+ * something else; the suite runs serially to keep that unlikely, and the
+ * backend service treats an occupied port as an externally managed backend
+ * rather than failing.
+ * @return {Promise<number>} an available port
+ */
+const reserveFreePort = () => new Promise((resolve, reject) => {
+  const server = net.createServer();
+  server.unref();
+  server.on('error', reject);
+  server.listen(0, '127.0.0.1', () => {
+    const {port} = server.address();
+    server.close(() => resolve(port));
+  });
+});
+
+// Playwright fixtures that launch the Electron app in isolation: every test
+// gets a freshly reserved backend port and a throwaway userData directory, so
+// tests never assume port 7301 is free and never read or modify the real
+// user's credentials or settings.
+const test = base.extend({
+  // Playwright derives fixture dependencies from the destructured first
+  // argument; these two have none, hence the empty pattern.
+  // eslint-disable-next-line no-empty-pattern
+  backendPort: async ({}, use) => {
+    await use(await reserveFreePort());
+  },
+
+  // eslint-disable-next-line no-empty-pattern
+  userDataDir: async ({}, use) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eeg2bids-userdata-'));
+    await use(dir);
+    fs.rmSync(dir, {recursive: true, force: true});
+  },
+
+  electronApp: async ({backendPort, userDataDir}, use) => {
+    const electronApp = await electron.launch({
+      // Load the app from the repo root (package.json "main"); no DEV env, so
+      // the production renderer build under build/ is used.
+      args: [REPO_ROOT],
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        EEG2BIDS_BACKEND_PORT: String(backendPort),
+        EEG2BIDS_USER_DATA_DIR: userDataDir,
+      },
+    });
+    await use(electronApp);
+    await electronApp.close();
+  },
+
+  mainWindow: async ({electronApp}, use) => {
+    const window = await electronApp.firstWindow();
+    await use(window);
+  },
+});
+
+const {expect} = require('@playwright/test');
+
+module.exports = {test, expect, REPO_ROOT, reserveFreePort};

--- a/electron/tests/fixtures.js
+++ b/electron/tests/fixtures.js
@@ -47,11 +47,12 @@ const canConnect = (port) => new Promise((resolve) => {
  * @param {object} options - backendPort, userDataDir and optional extra env
  * @return {Promise<ElectronApplication>} the launched app
  */
-const launchElectron = ({backendPort, userDataDir, env = {}}) =>
+const launchElectron = ({backendPort, userDataDir, env = {}, args = []}) =>
   electron.launch({
     // Load the app from the repo root (package.json "main"); no DEV env, so
-    // the production renderer build under build/ is used.
-    args: [REPO_ROOT],
+    // the production renderer build under build/ is used. Extra args (e.g.
+    // Chromium switches like --password-store) go after the app path.
+    args: [REPO_ROOT, ...args],
     cwd: REPO_ROOT,
     env: {
       ...process.env,

--- a/electron/tests/fixtures.js
+++ b/electron/tests/fixtures.js
@@ -24,6 +24,43 @@ const reserveFreePort = () => new Promise((resolve, reject) => {
   });
 });
 
+/**
+ * Whether a TCP connection to a loopback port succeeds right now. Used to
+ * verify backend port availability independently of the renderer's Socket.IO
+ * connection.
+ * @param {number} port - the port to probe
+ * @return {Promise<boolean>} true when a connection is accepted
+ */
+const canConnect = (port) => new Promise((resolve) => {
+  const socket = net.connect({host: '127.0.0.1', port});
+  socket.once('connect', () => {
+    socket.destroy();
+    resolve(true);
+  });
+  socket.once('error', () => resolve(false));
+});
+
+/**
+ * Launch the Electron app from the repo root against the production renderer
+ * build, with the isolation env vars set. Callers that use this directly
+ * (rather than the electronApp fixture) own closing the returned app.
+ * @param {object} options - backendPort, userDataDir and optional extra env
+ * @return {Promise<ElectronApplication>} the launched app
+ */
+const launchElectron = ({backendPort, userDataDir, env = {}}) =>
+  electron.launch({
+    // Load the app from the repo root (package.json "main"); no DEV env, so
+    // the production renderer build under build/ is used.
+    args: [REPO_ROOT],
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      EEG2BIDS_BACKEND_PORT: String(backendPort),
+      EEG2BIDS_USER_DATA_DIR: userDataDir,
+      ...env,
+    },
+  });
+
 // Playwright fixtures that launch the Electron app in isolation: every test
 // gets a freshly reserved backend port and a throwaway userData directory, so
 // tests never assume port 7301 is free and never read or modify the real
@@ -44,17 +81,7 @@ const test = base.extend({
   },
 
   electronApp: async ({backendPort, userDataDir}, use) => {
-    const electronApp = await electron.launch({
-      // Load the app from the repo root (package.json "main"); no DEV env, so
-      // the production renderer build under build/ is used.
-      args: [REPO_ROOT],
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        EEG2BIDS_BACKEND_PORT: String(backendPort),
-        EEG2BIDS_USER_DATA_DIR: userDataDir,
-      },
-    });
+    const electronApp = await launchElectron({backendPort, userDataDir});
     await use(electronApp);
     await electronApp.close();
   },
@@ -67,4 +94,6 @@ const test = base.extend({
 
 const {expect} = require('@playwright/test');
 
-module.exports = {test, expect, REPO_ROOT, reserveFreePort};
+module.exports = {
+  test, expect, REPO_ROOT, reserveFreePort, canConnect, launchElectron,
+};

--- a/electron/tests/interactions.spec.js
+++ b/electron/tests/interactions.spec.js
@@ -1,0 +1,76 @@
+const {test, expect} = require('./fixtures');
+
+// Native OS boundaries (file dialogs, opening the browser, window creation)
+// are intercepted at runtime with electronApp.evaluate, which stubs the
+// shared electron `dialog`/`shell` objects the main process already captured.
+// Nothing test-only ships in the app, and no real dialog or browser opens.
+
+test.describe('directory selection', () => {
+  test('returns the chosen directory', async ({electronApp, mainWindow}) => {
+    await electronApp.evaluate(({dialog}, chosen) => {
+      dialog.showOpenDialog = async () => (
+        {canceled: false, filePaths: [chosen]}
+      );
+    }, '/tmp/eeg2bids-selected');
+
+    const dir = await mainWindow.evaluate(
+        () => window.eeg2bids.selectDirectory(),
+    );
+    expect(dir).toBe('/tmp/eeg2bids-selected');
+  });
+
+  test('returns null when cancelled', async ({electronApp, mainWindow}) => {
+    await electronApp.evaluate(({dialog}) => {
+      dialog.showOpenDialog = async () => ({canceled: true, filePaths: []});
+    });
+
+    const dir = await mainWindow.evaluate(
+        () => window.eeg2bids.selectDirectory(),
+    );
+    expect(dir).toBeNull();
+  });
+});
+
+test.describe('settings window', () => {
+  test('opens a second window on the settings route', async ({
+    electronApp, mainWindow,
+  }) => {
+    expect(electronApp.windows()).toHaveLength(1);
+
+    const [settingsWindow] = await Promise.all([
+      electronApp.waitForEvent('window'),
+      mainWindow.evaluate(() => window.eeg2bids.openSettings()),
+    ]);
+    await settingsWindow.waitForLoadState('domcontentloaded');
+
+    expect(electronApp.windows()).toHaveLength(2);
+    expect(settingsWindow.url()).toContain('settings');
+  });
+});
+
+test.describe('external links', () => {
+  test('opens allowlisted URLs and rejects the rest', async ({
+    electronApp, mainWindow,
+  }) => {
+    // Record openExternal calls instead of launching the developer's browser.
+    await electronApp.evaluate(({shell}) => {
+      global.__opened = [];
+      shell.openExternal = async (url) => {
+        global.__opened.push(url);
+      };
+    });
+
+    const allowed = await mainWindow.evaluate(
+        () => window.eeg2bids.openExternal('https://mcin.ca'),
+    );
+    const rejected = await mainWindow.evaluate(
+        () => window.eeg2bids.openExternal('https://evil.example.com'),
+    );
+    const opened = await electronApp.evaluate(() => global.__opened);
+
+    expect(allowed).toBe(true);
+    expect(rejected).toBe(false);
+    // Only the allowlisted URL reached the native boundary.
+    expect(opened).toEqual(['https://mcin.ca']);
+  });
+});

--- a/electron/tests/shutdown.spec.js
+++ b/electron/tests/shutdown.spec.js
@@ -1,0 +1,60 @@
+const {test, expect, launchElectron, REPO_ROOT} = require('./fixtures');
+const path = require('path');
+
+const BACKEND_SERVICE = path.join(
+    REPO_ROOT, 'electron/main/backend-service.js',
+);
+
+/**
+ * Whether a process (or, with a negative pid, a process group) still exists.
+ * Signal 0 performs the permission/existence check without delivering a
+ * signal; EPERM means the process exists but is not ours to signal.
+ * @param {number} pid - the pid, or a negative process-group id
+ * @return {boolean} true when the process/group is still present
+ */
+const alive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+};
+
+// Clean shutdown must leave no owned backend process behind. The owned pid is
+// read from the app itself (the backend service tracks it), so the test never
+// inspects or terminates unrelated Python processes.
+test('shutdown terminates the owned backend process group', async ({
+  backendPort, userDataDir,
+}) => {
+  const app = await launchElectron({backendPort, userDataDir});
+  try {
+    const window = await app.firstWindow();
+
+    // Wait until the backend is actually up, so an owned pid exists.
+    await expect(window.locator('[data-testid="backend-status"]'))
+        .toHaveAttribute('data-state', 'connected', {timeout: 120000});
+
+    const pid = await app.evaluate(
+        // eslint-disable-next-line no-empty-pattern
+        async ({}, modulePath) =>
+          process.mainModule.require(modulePath).getOwnedPid(),
+        BACKEND_SERVICE,
+    );
+    expect(typeof pid).toBe('number');
+    expect(pid).toBeGreaterThan(0);
+    expect(alive(pid)).toBe(true);
+    // The child is detached, so its pid is also its process-group id.
+    expect(alive(-pid)).toBe(true);
+
+    await app.close();
+
+    // The whole owned process group is gone shortly after quit.
+    await expect.poll(() => alive(-pid), {timeout: 8000}).toBe(false);
+    expect(alive(pid)).toBe(false);
+  } finally {
+    // close() is idempotent enough here; guard against a still-open app if an
+    // assertion threw before the explicit close above.
+    await app.close().catch(() => {});
+  }
+});

--- a/electron/tests/smoke.spec.js
+++ b/electron/tests/smoke.spec.js
@@ -1,0 +1,14 @@
+const {test, expect} = require('./fixtures');
+
+// Smoke test: the app launches against the production renderer build and the
+// renderer reaches a stable readiness state. The fixture owns clean shutdown
+// and the isolated port/userData directory.
+test('launches and renders the app', async ({mainWindow}) => {
+  // The readiness anchor is always present once the renderer mounts.
+  const appRoot = mainWindow.locator('[data-testid="app-root"]');
+  await expect(appRoot).toBeAttached();
+
+  // The splash screen advances to the Welcome step on its own, confirming the
+  // renderer is running rather than merely loaded.
+  await expect(appRoot).toHaveAttribute('data-appmode', 'Welcome');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@vitejs/plugin-react": "^6.0.3",
         "concurrently": "^10.0.3",
         "electron": "^43.1.1",
@@ -375,6 +376,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3642,6 +3659,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@vitejs/plugin-react": "^6.0.3",
     "concurrently": "^10.0.3",
     "electron": "^43.1.1",
@@ -31,7 +32,8 @@
     "build": "vite build",
     "electron-start": "DEV=1 electron .",
     "start": "npm run dev",
-    "lint": "eslint src electron"
+    "lint": "eslint src electron",
+    "test:electron": "npm run build && playwright test"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css,md}": [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+const {defineConfig} = require('@playwright/test');
+
+// Linux-first Playwright Electron integration suite (see electron/tests/).
+// Automated Electron coverage initially targets the supported Linux
+// development environment; cross-platform packaging is out of scope.
+//
+// Tests drive the production renderer build (npm run test:electron runs the
+// build first). They must not assume the fixed development port 7301 and must
+// never touch the real user's credentials — the launch fixture reserves a free
+// port and an isolated userData directory for every app instance.
+module.exports = defineConfig({
+  testDir: './electron/tests',
+  // Electron app instances share this machine's single display and the same
+  // repo checkout; run serially to keep backend ports and process ownership
+  // unambiguous.
+  workers: 1,
+  fullyParallel: false,
+  // The first launch may run `uv run`, which can build the Python environment;
+  // allow a generous per-test budget. Individual waits still fail fast when the
+  // backend reports a failed state.
+  timeout: 180000,
+  expect: {timeout: 15000},
+  reporter: [['list']],
+  use: {
+    trace: 'retain-on-failure',
+  },
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,11 @@ import './css/App.css';
 
 // Socket.io
 import {Socket} from './jsx/socket.io';
-const uri = 'http://127.0.0.1:7301';
+// The backend port is configurable (see electron/main/backend-service.js); the
+// preload bridge exposes the value the main process chose. Fall back to 7301
+// when the bridge is unavailable (e.g. renderer opened outside Electron).
+const backendPort = window.eeg2bids?.getBackendPort?.() ?? 7301;
+const uri = `http://127.0.0.1:${backendPort}`;
 const options = {
   // Prefer websocket, but allow long-polling as a fallback: the backend
   // serves both, and polling keeps the app usable if the websocket

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,6 +64,13 @@ const App = () => {
         },
       }}>
         <>
+          {/* Stable readiness anchor for integration tests: always present,
+              carries the current app mode, and renders no box of its own. */}
+          <div
+            data-testid='app-root'
+            data-appmode={appMode}
+            style={{display: 'contents'}}
+          />
           <BackendStatus/>
           {/*<Help visible={appMode !== 'SplashScreen'} activeMode={appMode}/>*/}
           <Menu visible={appMode !== 'SplashScreen'}

--- a/src/jsx/elements/backendStatus.jsx
+++ b/src/jsx/elements/backendStatus.jsx
@@ -96,6 +96,8 @@ const BackendStatus = () => {
   return (
     <div
       className='backend-status'
+      data-testid='backend-status'
+      data-state={status.key}
       title={backend.error || status.label}
       style={{
         position: 'fixed',

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,10 @@ import react from '@vitejs/plugin-react';
  * place of the %CSP% token. The dev variant additionally allows inline
  * scripts (Vite's react-refresh preamble) and the HMR websocket; production
  * allows no inline scripts at all. connect-src covers the local Python
- * Socket.IO backend on 127.0.0.1:7301 (polling + websocket transports).
+ * Socket.IO backend (polling + websocket transports); the backend port is
+ * configurable at runtime, so any loopback port is allowed. The policy is
+ * baked in at build time and cannot know the chosen port, but the backend
+ * only ever binds 127.0.0.1, so this stays loopback-only.
  * @param {boolean} dev - true for the dev server, false for a build
  * @return {string} the policy string
  */
@@ -16,7 +19,7 @@ const contentSecurityPolicy = (dev) => [
   `style-src 'self' 'unsafe-inline'`,
   `img-src 'self' data:`,
   `font-src 'self' data:`,
-  `connect-src 'self' http://127.0.0.1:7301 ws://127.0.0.1:7301` +
+  `connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*` +
     (dev ? ' ws://localhost:3000' : ''),
 ].join('; ');
 


### PR DESCRIPTION
## Summary

Adds the Linux-first Playwright Electron integration suite and the application seams needed to test Electron safely and deterministically.

### Electron test infrastructure

- add Playwright configuration, shared Electron fixtures, and the stable `npm run test:electron` command
- build and test the production renderer rather than relying on the Vite development server
- allocate an available backend port for each launch instead of assuming port 7301 is free
- isolate every test launch in a temporary Electron user-data directory
- add explicit test-only hooks for native dialogs, external links, settings windows, and backend failure scenarios
- add stable renderer and backend readiness selectors instead of arbitrary sleeps

### Integration coverage

- launch Electron and verify the renderer becomes ready
- assert the complete preload bridge API and configured backend port
- verify backend startup, port availability, renderer Socket.IO connection, and immediate failure reporting
- cover directory selection and cancellation
- cover settings-window creation
- verify allowlisted external links open while disallowed links are rejected
- verify credential save/read/remove using isolated user data and deterministic test password storage
- verify application shutdown terminates the exact owned backend process group

### Runtime changes

- support `EEG2BIDS_USER_DATA_DIR` before Electron user data is accessed
- propagate a configurable backend port through Electron, Python, and the renderer while retaining port 7301 as the development default
- report the backend as running only after the configured port accepts connections
- track the backend process group so shutdown does not inspect or terminate unrelated Python processes
- expose the required preload methods and readiness state for application-boundary testing

## Testing

- `uv run pytest` — 65 passed
- `npm run test:electron` — 11 passed
- `npm run build` — passed as part of the Electron test command

> The local environment did not provide `xvfb-run`, so the Electron suite was run against the available display. CI can run the same stable command headlessly with `xvfb-run -a npm run test:electron`.

Closes #175
