### PR TITLE
Add native Linux and Windows packaging workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,111 @@
+# Native packaging validation for the supported Linux and Windows targets.
+# This workflow never publishes a GitHub Release. Issue #190 can consume these
+# jobs later for immutable release-candidate publication and promotion.
+name: Package
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/package.yml'
+      - 'electron/**'
+      - 'eeg2bids/**'
+      - 'tools/eeg2bids-backend.spec'
+      - 'tools/pyinstaller-rthooks/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pyproject.toml'
+      - 'uv.lock'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    name: Linux deb (x64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install locked Node dependencies
+        run: npm ci
+
+      - name: Install Electron runtime
+        run: npm run install:electron
+
+      - name: Build Linux package
+        run: npm run dist:linux
+
+      - name: Generate checksum
+        run: |
+          cd dist/electron
+          sha256sum *.deb > SHA256SUMS
+
+      - name: Upload Linux candidate
+        uses: actions/upload-artifact@v7
+        with:
+          name: eeg2bids-linux-x64-${{ github.sha }}
+          path: |
+            dist/electron/*.deb
+            dist/electron/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14
+
+  windows:
+    name: Windows NSIS (x64)
+    runs-on: windows-2025
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install locked Node dependencies
+        run: npm ci
+
+      - name: Install Electron runtime
+        run: npm run install:electron
+
+      - name: Build Windows package
+        run: npm run dist:windows
+
+      - name: Generate checksum
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem dist/electron/*-setup.exe
+          if ($installer.Count -ne 1) {
+            throw "Expected exactly one NSIS installer, found $($installer.Count)"
+          }
+          $hash = (Get-FileHash $installer.FullName -Algorithm SHA256).Hash.ToLower()
+          "$hash  $($installer.Name)" | Set-Content dist/electron/SHA256SUMS
+
+      - name: Upload Windows candidate
+        uses: actions/upload-artifact@v7
+        with:
+          name: eeg2bids-windows-x64-${{ github.sha }}
+          path: |
+            dist/electron/*-setup.exe
+            dist/electron/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -90,6 +90,79 @@ jobs:
       - name: Build Windows package
         run: npm run dist:windows
 
+      - name: Smoke test installed application
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem dist/electron/*-setup.exe
+          if ($installer.Count -ne 1) {
+            throw "Expected exactly one NSIS installer, found $($installer.Count)"
+          }
+          Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait
+          $app = Get-ChildItem "$env:LOCALAPPDATA/Programs/eeg2bids" `
+            -Filter 'eeg2bids.exe' -Recurse | Select-Object -First 1
+          if (-not $app) { throw 'Installed eeg2bids.exe was not found' }
+
+          $process = Start-Process -FilePath $app.FullName -PassThru
+          $connected = $false
+          for ($attempt = 0; $attempt -lt 120; $attempt++) {
+            try {
+              $client = [System.Net.Sockets.TcpClient]::new()
+              $client.Connect('127.0.0.1', 7301)
+              $client.Dispose()
+              $connected = $true
+              break
+            } catch {
+              Start-Sleep -Seconds 1
+            }
+          }
+          if (-not $connected) { throw 'Backend did not open port 7301' }
+
+          # The Windows watchdog defect appeared only after its first poll.
+          # Require the managed backend to remain available well beyond that.
+          Start-Sleep -Seconds 10
+          $client = [System.Net.Sockets.TcpClient]::new()
+          try {
+            $client.Connect('127.0.0.1', 7301)
+          } finally {
+            $client.Dispose()
+          }
+
+          $window = Get-Process eeg2bids | Where-Object MainWindowHandle -ne 0 |
+            Select-Object -First 1
+          if (-not $window -or -not $window.CloseMainWindow()) {
+            throw 'Could not close the installed application normally'
+          }
+          $window.WaitForExit(15000) | Out-Null
+          Start-Sleep -Seconds 5
+          if (Get-Process eeg2bids-backend -ErrorAction SilentlyContinue) {
+            throw 'Frozen backend remained after application shutdown'
+          }
+
+          $uninstaller = Get-ChildItem "$env:LOCALAPPDATA/Programs/eeg2bids" `
+            -Filter 'Uninstall*.exe' | Select-Object -First 1
+          if (-not $uninstaller) { throw 'NSIS uninstaller was not found' }
+          Start-Process -FilePath $uninstaller.FullName -ArgumentList '/S' -Wait
+
+      - name: Collect packaged application logs
+        if: always()
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force test-results/packaged-windows |
+            Out-Null
+          $log = Join-Path $env:APPDATA 'eeg2bids/logs/main.log'
+          if (Test-Path $log) {
+            Copy-Item $log test-results/packaged-windows/main.log
+          }
+
+      - name: Upload packaged application logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: eeg2bids-windows-smoke-logs-${{ github.sha }}
+          path: test-results/packaged-windows/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Generate checksum
         shell: pwsh
         run: |

--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -1,7 +1,7 @@
-# Linux manual QA
+# Production manual QA
 
 This guide covers human checks that add value beyond the automated Python and
-Electron suites. It initially targets Ubuntu 24.04 x86_64. Run the applicable
+Electron suites. It initially targets Ubuntu 24.04 x86_64 and Windows 11 x64. Run the applicable
 scenarios for application changes; run every release-gate scenario against a
 release candidate before promoting it to a final release.
 
@@ -239,6 +239,51 @@ policy.
 
 **Cleanup:** Delete the disposable VM or securely remove transferred test data
 and candidate artifacts.
+
+## Windows scenarios
+
+Use the exact Windows installer and `SHA256SUMS` downloaded together from the
+packaging workflow. Record the full commit SHA and workflow run URL. The initial
+installer is unsigned, so SmartScreen behavior is an expected observation, not
+something automation should suppress.
+
+### QA-WINDOWS-001: Clean install and full workflow
+
+**Release gate:** yes.
+
+On a clean Windows 11 x64 VM without Node, npm, uv, or Python, verify the SHA-256
+checksum, run the assisted per-user NSIS installer, and record any SmartScreen
+warning and the exact user-visible path through it. Launch EEG2BIDS from the
+Start menu. Confirm the backend connects, then perform the anonymized conversion
+and validation described in QA-LINUX-001 using synthetic data.
+
+**Expected:** Installation requires no development tooling or administrator
+access; the installed renderer and frozen backend complete the representative
+workflow. The unsigned-app warning is documented clearly and no security control
+is disabled by the application.
+
+### QA-WINDOWS-002: Shutdown process cleanup
+
+**Release gate:** yes.
+
+With the installed application connected, record the relevant process baseline,
+quit normally, wait ten seconds, and inspect Task Manager or `Get-Process`.
+
+**Expected:** No application-owned EEG2BIDS, Electron, or frozen-backend process
+remains. Unrelated processes are unchanged.
+
+### QA-WINDOWS-003: Upgrade and uninstall
+
+**Release gate:** yes.
+
+Install a newer checksummed candidate over an existing per-user installation.
+Confirm it upgrades in place, launches, connects, and retains expected settings.
+Then uninstall it through Windows Settings.
+
+**Expected:** There is one upgraded installation; installer-owned files and Start
+menu integration are removed on uninstall; no owned process remains; user
+settings and credentials are retained according to policy without exposing their
+contents.
 
 ## Reporting results
 

--- a/docs/windows-packaging.md
+++ b/docs/windows-packaging.md
@@ -1,0 +1,44 @@
+# Windows production packaging
+
+The initial supported Windows target is **Windows 11 x64**. The application is
+packaged as an unsigned, per-user NSIS installer by electron-builder. Signing is
+deferred; Windows SmartScreen may therefore identify the download as an
+unrecognized application.
+
+## Build
+
+A Windows package must be built on Windows because PyInstaller produces a
+platform-native frozen backend:
+
+```powershell
+npm ci
+npm run install:electron
+npm run dist:windows
+```
+
+The installer is written to `dist/electron/`. It includes Electron, the renderer,
+and the frozen Python backend; users do not need Node, npm, uv, or Python.
+
+`.github/workflows/package.yml` performs this build on a GitHub-hosted Windows
+runner and uploads the installer and `SHA256SUMS` as workflow artifacts. It does
+not publish releases. The same workflow builds the Linux `.deb`, giving future
+release automation one native build interface to consume.
+
+## Installation lifecycle
+
+- The assisted NSIS installer runs per-user and does not request elevation.
+- A newer installer upgrades the application in place because releases retain
+  the same application ID.
+- Uninstall removes installer-owned application files.
+- User settings and credentials are retained on uninstall.
+- The initial unsigned installer may trigger a SmartScreen warning. Do not
+  disable or bypass Windows security controls programmatically; manual QA records
+  the warning and the user-visible path explicitly.
+
+## Verification boundary
+
+CI is responsible for reproducibly building the native artifact from
+`package-lock.json` and `uv.lock`, generating its checksum, and retaining both
+together. Windows manual QA verifies the interactive installer, SmartScreen,
+Start menu integration, installed application workflow, upgrade, shutdown, and
+uninstall against that exact checksummed artifact.

--- a/docs/windows-packaging.md
+++ b/docs/windows-packaging.md
@@ -35,10 +35,24 @@ release automation one native build interface to consume.
   disable or bypass Windows security controls programmatically; manual QA records
   the warning and the user-visible path explicitly.
 
+## Diagnostics
+
+The installed application writes main-process and captured backend output to:
+
+```text
+%APPDATA%\eeg2bids\logs\main.log
+```
+
+The log records backend launch, readiness, output, exit, and IPC failures. Review
+and sanitize it before sharing; application code must never log credentials or
+clinical data.
+
 ## Verification boundary
 
 CI is responsible for reproducibly building the native artifact from
-`package-lock.json` and `uv.lock`, generating its checksum, and retaining both
-together. Windows manual QA verifies the interactive installer, SmartScreen,
-Start menu integration, installed application workflow, upgrade, shutdown, and
-uninstall against that exact checksummed artifact.
+`package-lock.json` and `uv.lock`, silently installing it, confirming the managed
+backend remains available, closing it normally, checking process cleanup,
+uninstalling it, generating its checksum, and retaining the artifact and logs.
+Windows manual QA verifies the interactive installer, SmartScreen, Start menu
+integration, visible application workflow, upgrade, and uninstall against that
+exact checksummed artifact.

--- a/eeg2bids/server.py
+++ b/eeg2bids/server.py
@@ -238,6 +238,49 @@ def disconnect(sid):
     print('disconnect: ', sid)
 
 
+def _windows_process_is_alive(pid):
+    """Return whether *pid* is alive using the native Windows process API.
+
+    ``os.kill(pid, 0)`` is a POSIX process-existence probe, but Python's Windows
+    implementation maps signals onto different Win32 semantics. Use a
+    non-terminating wait on a synchronization handle instead.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_timeout = 0x00000102
+    error_access_denied = 5
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL,
+                                     wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+    handle = kernel32.OpenProcess(synchronize, False, pid)
+    if not handle:
+        # Access denied proves that a process occupies the pid; do not kill the
+        # backend merely because Windows refuses a synchronization handle.
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == wait_timeout
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _owner_process_is_alive(pid):
+    """Return whether the Electron owner process still exists."""
+    if sys.platform == 'win32':
+        return _windows_process_is_alive(pid)
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
 def _watch_owner_process():
     """Exit when the process that owns this backend disappears.
 
@@ -254,11 +297,9 @@ def _watch_owner_process():
     def watch():
         while True:
             time.sleep(2)
-            try:
-                os.kill(int(owner_pid), 0)
-            except OSError:
-                # stderr is a pipe into the (now dead) owner, so this
-                # print may itself fail; exit regardless.
+            if not _owner_process_is_alive(int(owner_pid)):
+                # stderr is a pipe into the (now dead) owner, so this print may
+                # itself fail; exit regardless.
                 try:
                     print(
                         f'eeg2bids: owner process {owner_pid} exited, '

--- a/electron/main/backend-service.js
+++ b/electron/main/backend-service.js
@@ -153,11 +153,7 @@ const waitForReady = async (owned) => {
         `${BACKEND_PORT} within ${READINESS_TIMEOUT_MS / 1000}s of starting.`;
       console.error(`[backend] ${message}`);
       setStatus('failed', message);
-      try {
-        process.kill(-owned.pid, 'SIGTERM');
-      } catch (error) {
-        // already gone
-      }
+      terminateProcessTree(owned.pid, true);
       return;
     }
     await delay(READINESS_POLL_INTERVAL_MS);
@@ -235,8 +231,37 @@ const start = async () => {
 };
 
 /**
- * Terminate the owned backend process group, escalating to SIGKILL when
- * it ignores SIGTERM.
+ * Terminate an owned backend and its descendants. POSIX supports signaling the
+ * detached process group through a negative pid. Windows has no equivalent, so
+ * taskkill is used with /T to reach the complete process tree.
+ * @param {number} pid - root process id
+ * @param {boolean} force - whether to force termination
+ * @return {boolean} whether a termination request was started
+ */
+const terminateProcessTree = (pid, force = false) => {
+  if (process.platform === 'win32') {
+    const args = ['/PID', String(pid), '/T'];
+    if (force) {
+      args.push('/F');
+    }
+    const killer = spawn('taskkill.exe', args, {
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+    killer.on('error', () => {});
+    return true;
+  }
+  try {
+    process.kill(-pid, force ? 'SIGKILL' : 'SIGTERM');
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+/**
+ * Terminate the owned backend process tree, escalating when it ignores the
+ * initial request.
  * @return {Promise<void>} resolves once the child has exited
  */
 const stop = () => new Promise((resolve) => {
@@ -252,15 +277,9 @@ const stop = () => new Promise((resolve) => {
     resolve();
   });
   killTimer = setTimeout(() => {
-    try {
-      process.kill(-pid, 'SIGKILL');
-    } catch (error) {
-      // already gone
-    }
+    terminateProcessTree(pid, true);
   }, SIGKILL_TIMEOUT_MS);
-  try {
-    process.kill(-pid, 'SIGTERM');
-  } catch (error) {
+  if (!terminateProcessTree(pid)) {
     clearTimeout(killTimer);
     resolve();
   }

--- a/electron/main/index.js
+++ b/electron/main/index.js
@@ -6,6 +6,7 @@ const {
 } = require('./windows');
 const {registerIpcHandlers} = require('./ipc');
 const backendService = require('./backend-service');
+const {initializeLogging} = require('./logging');
 
 // Redirect all user data (settings + encrypted credentials) to an isolated
 // directory when asked. Integration tests point this at a temporary dir so
@@ -15,6 +16,7 @@ if (process.env.EEG2BIDS_USER_DATA_DIR) {
   app.setPath('userData', process.env.EEG2BIDS_USER_DATA_DIR);
 }
 
+initializeLogging(app);
 registerIpcHandlers();
 
 // Renderer content is untrusted: windows may only show our own renderer,

--- a/electron/main/logging.js
+++ b/electron/main/logging.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+let initialized = false;
+
+/**
+ * Tee main-process console output (including captured backend output) to a
+ * persistent file for installed-app diagnostics. Values still go to the
+ * original console and credentials are never logged by this module.
+ * @param {Electron.App} app - Electron application
+ * @return {string} path to the active log file
+ */
+const initializeLogging = (app) => {
+  if (initialized) {
+    return path.join(app.getPath('userData'), 'logs', 'main.log');
+  }
+  const logDir = path.join(app.getPath('userData'), 'logs');
+  fs.mkdirSync(logDir, {recursive: true});
+  const logPath = path.join(logDir, 'main.log');
+
+  for (const level of ['info', 'warn', 'error']) {
+    // This module deliberately wraps the process console as the source that is
+    // teed to the diagnostic file.
+    // eslint-disable-next-line no-console
+    const original = console[level].bind(console);
+    // eslint-disable-next-line no-console
+    console[level] = (...args) => {
+      original(...args);
+      const message = util.format(...args).replaceAll('\r', '');
+      const line = `${new Date().toISOString()} ${level.toUpperCase()} ` +
+        `${message}\n`;
+      try {
+        fs.appendFileSync(logPath, line, {encoding: 'utf8'});
+      } catch (error) {
+        original(`[electron:main] could not write ${logPath}:`, error);
+      }
+    };
+  }
+  initialized = true;
+  console.info(`[electron:main] logging to ${logPath}`);
+  return logPath;
+};
+
+module.exports = {initializeLogging};

--- a/electron/tests/shutdown.spec.js
+++ b/electron/tests/shutdown.spec.js
@@ -44,14 +44,18 @@ test('shutdown terminates the owned backend process group', async ({
     expect(typeof pid).toBe('number');
     expect(pid).toBeGreaterThan(0);
     expect(alive(pid)).toBe(true);
-    // The child is detached, so its pid is also its process-group id.
-    expect(alive(-pid)).toBe(true);
+    // POSIX exposes the detached process group through a negative pid.
+    // Windows process trees are terminated with taskkill /T instead.
+    if (process.platform !== 'win32') {
+      expect(alive(-pid)).toBe(true);
+    }
 
     await app.close();
 
-    // The whole owned process group is gone shortly after quit.
-    await expect.poll(() => alive(-pid), {timeout: 8000}).toBe(false);
-    expect(alive(pid)).toBe(false);
+    if (process.platform !== 'win32') {
+      await expect.poll(() => alive(-pid), {timeout: 8000}).toBe(false);
+    }
+    await expect.poll(() => alive(pid), {timeout: 8000}).toBe(false);
   } finally {
     // close() is idempotent enough here; guard against a still-open app if an
     // assertion threw before the explicit close above.

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "lint": "eslint src electron",
     "test:unit": "vitest run",
     "test:electron": "npm run build && playwright test",
-    "freeze:backend": "bash tools/freeze-backend.sh",
+    "freeze:backend": "uv run --frozen --group packaging pyinstaller --noconfirm --distpath dist --workpath dist/.pyinstaller-work tools/eeg2bids-backend.spec",
     "dist:dir": "npm run build && npm run freeze:backend && electron-builder --linux dir",
-    "dist:linux": "npm run build && npm run freeze:backend && electron-builder --linux"
+    "dist:linux": "npm run build && npm run freeze:backend && electron-builder --linux deb",
+    "dist:windows": "npm run build && npm run freeze:backend && electron-builder --win nsis --x64"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css,md}": [
@@ -78,6 +79,19 @@
       "category": "Science",
       "icon": "public/logo512.png",
       "syncDesktopName": true
+    },
+    "win": {
+      "target": [
+        "nsis"
+      ],
+      "artifactName": "EEG2BIDS-${version}-windows-${arch}-setup.${ext}"
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowElevation": false,
+      "allowToChangeInstallationDirectory": true,
+      "deleteAppDataOnUninstall": false
     }
   },
   "engines": {

--- a/tests/test_owner_process.py
+++ b/tests/test_owner_process.py
@@ -1,0 +1,27 @@
+"""Cross-platform tests for the packaged backend owner watchdog."""
+from unittest.mock import patch
+
+from eeg2bids import server
+
+
+def test_posix_owner_probe_reports_live_process():
+    with patch.object(server.sys, 'platform', 'linux'), \
+            patch.object(server.os, 'kill') as kill:
+        assert server._owner_process_is_alive(1234)
+        kill.assert_called_once_with(1234, 0)
+
+
+def test_posix_owner_probe_reports_missing_process():
+    with patch.object(server.sys, 'platform', 'linux'), \
+            patch.object(server.os, 'kill', side_effect=ProcessLookupError):
+        assert not server._owner_process_is_alive(1234)
+
+
+def test_windows_owner_probe_uses_native_check():
+    with patch.object(server.sys, 'platform', 'win32'), \
+            patch.object(server, '_windows_process_is_alive',
+                         return_value=True) as probe, \
+            patch.object(server.os, 'kill') as kill:
+        assert server._owner_process_is_alive(1234)
+        probe.assert_called_once_with(1234)
+        kill.assert_not_called()


### PR DESCRIPTION
## Summary

- add native Ubuntu `.deb` and Windows x64 NSIS packaging jobs
- generate SHA-256 manifests and retain checksummed workflow artifacts
- make backend freezing cross-platform and terminate owned backend process trees on Windows
- document the initial Windows support policy and extend manual QA to the exact Windows artifact

This establishes the simplest non-publishing packaging foundation for #188. The broader release-candidate publication and promotion workflow remains for #190 to consume later.

## Windows decisions

- Windows 11 x64
- assisted, per-user NSIS installation without elevation
- in-place upgrades
- preserve settings and credentials on uninstall
- unsigned initially; document and manually verify SmartScreen behavior

## Verification

- `npm run lint`
- `npm run test:unit`
- `git diff --check`

The Electron suite was not run locally because this Linux environment does not have `xvfb-run`. The new workflow's first native runs will validate the platform packaging toolchains; package installation and launch smoke automation is the next layer after those builds are stable.

Closes #188
