### PR TITLE
Update docs for Linux and Windows packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ metadata, events, validation, and optional LORIS workflows.
 
 ## Project status
 
-**Linux is the supported target for both development and production.** The
-Python backend was modernized in
+**Linux is the supported development target. Production packages are supported
+for Ubuntu and Windows 11 x64.** The Python backend was modernized in
 [#135](https://github.com/aces/EEG2BIDS/issues/135) (uv-managed package) and the
 Electron/renderer toolchain in
 [#137](https://github.com/aces/EEG2BIDS/issues/137) (Electron 43, Vite,
@@ -25,11 +25,12 @@ A supported Linux production build landed in
 [#170](https://github.com/aces/EEG2BIDS/issues/170): a `.deb` that bundles the
 Electron app and the PyInstaller-frozen Python backend, with Chromium sandbox
 integration for Ubuntu 24.04+. See [Packaging](#packaging) to build it and the
-[installation guide](docs/installation.md) to install it. Windows and macOS
-production builds are tracked in
-[#188](https://github.com/aces/EEG2BIDS/issues/188) and
-[#189](https://github.com/aces/EEG2BIDS/issues/189); cross-platform release
-automation in [#190](https://github.com/aces/EEG2BIDS/issues/190).
+[installation guide](docs/installation.md) to install it. A Windows 11 x64 NSIS
+build landed in [#188](https://github.com/aces/EEG2BIDS/issues/188), including a
+frozen backend, Windows process lifecycle support, and native CI smoke testing.
+See the [Windows packaging guide](docs/windows-packaging.md). macOS packaging is
+tracked in [#189](https://github.com/aces/EEG2BIDS/issues/189), and coordinated
+release automation in [#190](https://github.com/aces/EEG2BIDS/issues/190).
 
 Automated backend and Electron integration suites are available for the
 supported Linux environment; see the [testing guide](docs/testing.md).
@@ -137,8 +138,9 @@ On headless Linux, run the Electron suite with
 ### Credential storage
 
 LORIS credentials are encrypted with Electron `safeStorage` and persisted
-under the application `userData` directory (`~/.config/eeg2bids/`), separate
-from ordinary settings such as the LORIS URL. On Linux, secure encryption
+under the application `userData` directory (`~/.config/eeg2bids/` on Linux,
+`%APPDATA%\eeg2bids\` on Windows), separate from ordinary settings such as the
+LORIS URL. On Linux, secure encryption
 requires a secret service (GNOME Keyring or KWallet). When only the
 `basic_text` fallback is available, the app logs an explicit warning that
 credentials are obfuscated rather than encrypted; when no backend exists at
@@ -176,24 +178,31 @@ Do not work around it with `--no-sandbox`.
 
 ## Packaging
 
-A supported Linux production build is available: a `.deb` bundling the Electron
-app, the renderer, and the Python backend frozen with PyInstaller, so end users
-need neither Node, npm, uv, nor a Python interpreter. See the
-[installation guide](docs/installation.md) for supported environments and
-install/uninstall behavior, and
-[docs/linux-packaging-design.md](docs/linux-packaging-design.md) for the design
-and rationale.
+Supported production packages bundle the Electron app, renderer, and
+PyInstaller-frozen Python backend, so end users need neither Node, npm, uv, nor
+a Python interpreter:
 
-Build it from the authoritative lockfiles:
+- Ubuntu amd64: `.deb`
+- Windows 11 x64: unsigned, per-user NSIS installer
+
+Build natively from the authoritative lockfiles:
 
 ```sh
-npm run dist:linux   # vite build -> freeze backend -> electron-builder .deb
+npm run dist:linux     # on Linux: .deb
+npm run dist:windows   # on Windows: x64 NSIS installer
 ```
 
-The artifact is written to `dist/electron/eeg2bids_<version>_amd64.deb`. The
-freeze step alone is `npm run freeze:backend`, which runs PyInstaller against
-`tools/eeg2bids-backend.spec` after installing the build-only `packaging`
-dependency group (`uv sync --group packaging`); the backend has a single entry
-point (`python -m eeg2bids`, also the `eeg2bids` console script).
+Artifacts are written to `dist/electron/`. PyInstaller must run on the target
+operating system; the Windows backend cannot be cross-compiled from Linux. The
+freeze step alone is `npm run freeze:backend`, using
+`tools/eeg2bids-backend.spec` and the locked `packaging` dependency group.
 
-Windows and macOS production builds are not yet available (#188, #189).
+The `Package` GitHub Actions workflow builds both platforms natively, smoke
+tests the installed Windows application and managed backend, generates
+`SHA256SUMS`, and uploads workflow artifacts. It does not publish a GitHub
+Release; coordinated candidate publication and promotion remain in #190.
+
+See the [installation guide](docs/installation.md), the
+[Windows packaging guide](docs/windows-packaging.md), and the historical
+[Linux packaging design](docs/linux-packaging-design.md). macOS is not yet
+supported (#189).

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -76,7 +76,8 @@ The export is temporary and must not be committed.
 
 ### Optional dependency groups
 
-- `packaging`: `pyinstaller`, reserved for future standalone packaging work
+- `packaging`: `pyinstaller`, used to freeze the production backend natively on
+  Linux and Windows
 - build system: `hatchling`, used to build the Python package
 
 These groups are not part of the normal application runtime. Audit them when
@@ -88,7 +89,7 @@ changing packaging.
 Dependabot beta ecosystem so updates modify the authoritative `uv.lock`
 rather than recreating a legacy requirements file.
 
-The CI work tracked by issue #147 should run, at minimum:
+The required CI workflow runs, at minimum:
 
 ```sh
 npm ci

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,10 +6,11 @@ current manual sanity checks. For installation prerequisites (Node, uv, secret
 service) see the [README](../README.md). For the canonical automated test
 commands and fixture policy, see [Testing](testing.md).
 
-Linux is the supported development target. To build and install the Linux
-production `.deb` see [Packaging](../README.md#packaging) and the
-[installation guide](installation.md); Windows and macOS production builds are
-not yet available (#188, #189).
+Linux is the supported development target. Production packages are available
+for Ubuntu and Windows 11 x64. See [Packaging](../README.md#packaging), the
+[installation guide](installation.md), and the
+[Windows packaging guide](windows-packaging.md). macOS packaging remains
+tracked in #189.
 
 ## Launching
 
@@ -123,7 +124,7 @@ validation. A failed or unreachable LORIS produces a visible login error
 ## Manual QA
 
 The former provisional Socket.IO and happy-path checks have been reviewed and
-consolidated into [Linux manual QA](manual-qa.md). That guide assigns stable
+consolidated into [production manual QA](manual-qa.md). That guide assigns stable
 scenario IDs and covers only human-observable value beyond the automated test
 baseline, including development and packaged workflows, anonymization,
 connection recovery, process cleanup, and release-candidate reporting.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,93 +1,91 @@
-# Installing EEG2BIDS (Linux)
+# Installing EEG2BIDS
 
-This guide is for **installing and running** the EEG2BIDS desktop application
-from a production `.deb` package. It requires no development tooling — Node,
-npm, uv, and Python do **not** need to be installed. To build the `.deb`
-yourself see [Packaging](../README.md#packaging); to run from a source checkout
-see the [development guide](development.md).
+Production packages include Electron, the renderer, and the frozen Python
+backend. End users do not need Node, npm, uv, or Python. To build a package see
+[Packaging](../README.md#packaging); to run from source see the
+[development guide](development.md).
 
-## Supported environment
+## Supported environments
 
-- **Ubuntu 24.04 LTS or newer, amd64** — the primary supported target.
-- **Ubuntu 22.04 LTS, amd64** — supported. (The AppArmor sandbox profile the
-  installer ships targets a newer AppArmor and is automatically skipped here;
-  the app still runs correctly.)
-- A **graphical desktop session** (X11 or Wayland).
-- A **secret service** — GNOME Keyring or KWallet — if you use the LORIS
-  integration. Credentials are encrypted through it; without one the app still
-  runs but can only obfuscate saved credentials and will warn you.
+- **Ubuntu 24.04 LTS or newer, amd64** — primary Linux target.
+- **Ubuntu 22.04 LTS, amd64** — supported with the installer's AppArmor
+  fallback.
+- **Windows 11, x64** — installed per-user with NSIS.
+- A graphical desktop session.
+- On Linux, GNOME Keyring or KWallet is required to encrypt saved LORIS
+  credentials. Without a secret service, the app warns that it can only
+  obfuscate them.
 
-Other Debian-family distributions may work but are not verified. Non-amd64
-architectures, Windows, and macOS are not yet supported (Windows and macOS are
-tracked in #188 and #189).
+Other Debian-family distributions may work but are not verified. Other
+architectures, older Windows versions, and macOS are not supported.
 
-## Install
+## Ubuntu
+
+### Install and launch
 
 ```sh
 sudo apt install ./eeg2bids_<version>_amd64.deb
-```
-
-Using `apt install ./file.deb` (rather than `dpkg -i`) also pulls in any system
-dependencies. The application installs to `/opt/EEG2BIDS/`, adds a launcher to
-your applications menu, and creates the command `eeg2bids` on your `PATH`.
-
-### The Chromium sandbox is handled for you
-
-Ubuntu 24.04+ restricts the unprivileged user namespaces that Chromium's
-sandbox relies on. The installer resolves this during installation — it enables
-a setuid sandbox helper only on systems that need it, and installs an AppArmor
-profile where supported. **You do not need to run `chown`, `chmod`, edit
-AppArmor, or launch with `--no-sandbox`.** The application runs fully sandboxed.
-
-## Launch
-
-From your applications menu (search "EEG2BIDS"), or from a terminal:
-
-```sh
 eeg2bids
 ```
 
-## Upgrade
+Using `apt install ./file.deb` also installs system dependencies. EEG2BIDS is
+installed under `/opt/EEG2BIDS/`, with an applications-menu launcher and an
+`eeg2bids` command.
 
-Install a newer `.deb` the same way; it replaces the previous version and
-re-applies the sandbox integration automatically:
+Ubuntu 24.04+ restricts the user namespaces Chromium's sandbox uses. The
+installer configures the sandbox helper and an AppArmor profile where supported.
+Do not manually run `chown`, change AppArmor, or use `--no-sandbox`.
+
+### Upgrade and uninstall
+
+Install a newer `.deb` in the same way. It replaces the previous version and
+re-applies sandbox integration.
 
 ```sh
 sudo apt install ./eeg2bids_<newer-version>_amd64.deb
-```
-
-## Uninstall
-
-```sh
 sudo apt remove eeg2bids
 ```
 
-This removes the installed application under `/opt/EEG2BIDS/`, the `PATH`
-command, and the AppArmor profile the installer added (unloading it from the
-running kernel).
+Uninstall removes package-owned files, commands, and AppArmor policy.
 
-### Your data is kept
+## Windows 11
 
-Uninstalling does **not** delete your personal data — your settings and any
-saved LORIS credentials live in your user profile
-(`~/.config/eeg2bids/`, credentials encrypted via the secret service), not in
-the installed package. Remove them yourself if you want a clean slate:
+Download the x64 NSIS installer and its `SHA256SUMS` from the same successful
+`Package` workflow artifact. Verify the checksum before installation, then run
+the assisted installer. It installs per-user without administrator access and
+adds EEG2BIDS to the Start menu.
 
-```sh
-rm -rf ~/.config/eeg2bids
-```
+The initial Windows installer is unsigned. Windows SmartScreen may identify it
+as an unrecognized application. Confirm the file came from the project workflow
+and that its checksum matches; the application does not disable or bypass
+Windows security controls.
 
-On a **shared computer**, remove saved LORIS credentials from within the app
-(or delete `~/.config/eeg2bids/`) after use.
+Run a newer installer to upgrade in place. Uninstall EEG2BIDS through Windows
+**Settings > Apps > Installed apps**.
+
+See [Windows production packaging](windows-packaging.md) for native build,
+workflow, lifecycle, diagnostics, and verification details.
+
+## User data and credentials
+
+Uninstalling on either platform retains personal settings and saved LORIS
+credentials:
+
+- Linux: `~/.config/eeg2bids/`
+- Windows: `%APPDATA%\eeg2bids\`
+
+Remove saved credentials inside the application before uninstalling, especially
+on a shared computer. Delete the corresponding profile directory only when you
+intend to remove all retained application data.
 
 ## Troubleshooting
 
-- **The window does not appear / the app exits immediately.** Launch from a
-  terminal (`eeg2bids`) to see diagnostics. Sandbox-related failures are logged
-  with actionable guidance. Do not work around them with `--no-sandbox`.
-- **"Backend unavailable" in the app.** The bundled backend failed to start;
-  the status area and terminal output describe why. The backend listens on
-  `127.0.0.1:7301`; if another program already uses that port the app assumes an
-  externally managed backend.
-- **Credentials only obfuscated, not encrypted.** No secret service is
-  available in your session; install/enable GNOME Keyring or KWallet.
+- **Backend unavailable:** another program may own `127.0.0.1:7301`, or the
+  bundled backend failed to start. Use the status indicator and **Restart
+  backend** after addressing the cause.
+- **Linux launch failure:** run `eeg2bids` in a terminal to see diagnostics. Do
+  not use `--no-sandbox`.
+- **Windows launch/backend failure:** inspect
+  `%APPDATA%\eeg2bids\logs\main.log`; it records main-process and captured
+  backend diagnostics. Sanitize logs before sharing them.
+- **Linux credentials only obfuscated:** enable GNOME Keyring or KWallet.

--- a/docs/linux-packaging-design.md
+++ b/docs/linux-packaging-design.md
@@ -1,9 +1,9 @@
-# Linux production packaging — design draft (issue #170)
+# Linux production packaging — implementation record (issue #170)
 
-**Status:** draft / proposal. Nothing here is committed to yet. This document
-exists to pressure-test an approach before we write build config, and to record
-*why* each choice was made so the Windows (#188) and macOS (#189) follow-ups can
-reuse the reasoning instead of rediscovering it.
+**Status:** implemented. This document began as the design proposal for #170 and
+retains its phased reasoning and historical verification notes. The current user
+instructions live in [Installation](installation.md); Windows implementation
+status lives in [Windows production packaging](windows-packaging.md).
 
 Read this alongside the issue text of #170. Where the issue says *what* must be
 true, this doc proposes *how*, and argues the trade-offs.
@@ -12,7 +12,7 @@ true, this doc proposes *how*, and argues the trade-offs.
 
 ## 1. What we're actually building
 
-Today EEG2BIDS only runs from a source checkout. A developer runs `uv sync`,
+Before production packaging, EEG2BIDS ran only from a source checkout. A developer runs `uv sync`,
 `npm ci`, `npm run dev`, and Electron launches the Python backend with
 `uv run --frozen python -m eeg2bids`. That is three separate toolchains (Node,
 uv, a Python interpreter) all assumed to be present, plus the repo itself on
@@ -241,16 +241,11 @@ checkout) rather than the current `DEV` env var alone.
    dev-server override. (Dev = load `localhost:3000`; packaged = load the
    bundled build; there's no "packaged but dev-server" case.)
 
-**One cross-platform bug to flag now, even though it's not a Linux blocker:**
-`backend-service.js` terminates the backend with `process.kill(-pid, ...)` on a
-`detached` process group. That negative-pid / process-group trick is
-**POSIX-only** — it works on Linux and macOS but **not on Windows**, so #188 will
-have to add a Windows teardown path (job objects or `taskkill /T /F`). The
-Python-side `EEG2BIDS_OWNER_PID` watchdog is already cross-platform, so the
-backend won't orphan even if the Electron-side kill is weaker on Windows — but
-the clean-shutdown guarantee needs Windows-specific work. Noting it here so
-#170's "shared architecture" doesn't accidentally bake in a POSIX assumption the
-follow-ups inherit silently.
+**Cross-platform lifecycle resolution:** the original process-group teardown was
+POSIX-only. #188 added a Windows path using `taskkill /T` with `/F` escalation,
+and changed the Python owner watchdog to use the native Windows process API
+rather than the POSIX `os.kill(pid, 0)` probe. Native CI now verifies that the
+installed Windows backend remains connected and exits with its owner.
 
 ---
 
@@ -403,9 +398,9 @@ Each phase is independently reviewable and de-risks the next.
   paths. Not verified here (needs root + system mutation → Phase 4): actually
   installing, and confirming a sandboxed launch with no `--no-sandbox`.
 
-  Minor open polish: electron-builder warns `desktopName`/`syncDesktopName` is
-  unset (window/.desktop association); harmless, easy follow-up. Package version
-  is still `1.0.5` (inherits package.json — see the version-source decision, §10).
+  The later polish set `desktopName`/`syncDesktopName` for correct desktop and
+  window association. Package versions now inherit the project version from
+  `package.json`.
 - **Phase 4 — Clean-machine verification.** Install the `.deb` on a fresh
   Ubuntu 24.04 VM/container with none of Node/npm/uv/Python present. Confirm:
   launches, sandbox on (not `--no-sandbox`), backend converts, credentials
@@ -434,7 +429,7 @@ Each phase is independently reviewable and de-risks the next.
 
 ---
 
-## 9. What #188 (Windows) and #189 (macOS) inherit from this
+## 9. What Windows and macOS inherit from this
 
 So the follow-ups stay "sparse" as intended, #170 nails down the shared spine:
 - The **PyInstaller freeze** of `__main__.py` (same on all three OSes; only the
@@ -445,12 +440,11 @@ So the follow-ups stay "sparse" as intended, #170 nails down the shared spine:
 - The launch contract (`EEG2BIDS_BACKEND_PORT`, `EEG2BIDS_OWNER_PID`, port-in-use
   → external).
 
-What they must add themselves (and why it can't be shared):
-- **Windows (#188):** a real child-process teardown (the POSIX process-group
-  kill doesn't exist); installer format (NSIS recommended); **Authenticode code
-  signing** (needs a cert — a procurement decision, not code) or users get
-  SmartScreen warnings.
-- **macOS (#189):** `.dmg`/`.pkg`; **code signing + notarization** (needs an
+Platform-specific status:
+- **Windows (#188, complete):** per-user NSIS on Windows 11 x64; native process
+  teardown and watchdog; unsigned initially, with SmartScreen warnings
+  documented; native CI build and installed-app smoke test.
+- **macOS (#189, pending):** `.dmg`/`.pkg`; **code signing + notarization** (needs an
   Apple Developer ID account — annual cost, org decision) or Gatekeeper blocks
   it on clean machines; hardened runtime; arm64 vs x86_64 (universal binary?).
   Neither Windows nor macOS has the AppArmor/userns problem — the whole §4
@@ -458,24 +452,19 @@ What they must add themselves (and why it can't be shared):
 
 ---
 
-## 10. Decisions needed from a human before/while building
+## 10. Resolved implementation decisions
 
-These are genuine forks I shouldn't silently pick:
-
-1. **Supported scope for v1:** Ubuntu 24.04 x86_64 only, or also 22.04 / arm64 /
-   non-AppArmor distros? (Narrower = faster to a real, *verified* artifact.)
-2. **AppArmor profile vs setuid helper as the *primary*** — I've proposed
-   "profile primary, setuid fallback." If we'd rather commit to one, that's a
-   call to make.
-3. **`.deb` first vs invest in Snap/Flatpak** for confinement-managed
-   sandboxing. I recommend `.deb` first; Snap is a legitimate alternative if the
-   team wants store distribution and can accept the file-access/credential
-   confinement work.
-4. **Version source of truth:** `package.json` and `pyproject.toml` both say
-   `1.0.5` but #191 targets a `3.0.0` release. The build needs one authoritative
-   version; where does it live and who bumps it?
-5. **Uninstall data policy:** keep user credentials/settings on uninstall
-   (proposed) vs purge them. Affects the `postrm` script.
+1. **Supported Linux scope:** Ubuntu 24.04+ amd64, with Ubuntu 22.04 supported
+   through the installer's AppArmor fallback.
+2. **Sandbox integration:** electron-builder's `.deb` lifecycle scripts select
+   the supported AppArmor/userns path and configure the narrowly scoped setuid
+   helper only when needed.
+3. **Package format:** `.deb`; Snap and Flatpak remain outside the supported
+   formats.
+4. **Version source:** electron-builder reads `package.json`; the Python project
+   version is kept aligned for the frozen backend package.
+5. **Uninstall data policy:** retain user settings and credentials while removing
+   installer-owned files and policy.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,9 +5,10 @@ conversion, and BIDS output behavior. The Playwright suite exercises the
 Electron application boundary and its integration with the Python backend.
 Both suites are required when a change can affect the application as a whole.
 
-Automated coverage initially targets the supported Linux development
-environment. See [Development](development.md) for the general development
-setup and launch architecture.
+The complete development suites run on Linux. Native packaging validation also
+builds Ubuntu and Windows artifacts and smoke tests the installed Windows
+application. See [Development](development.md) for the development setup and
+launch architecture.
 
 ## Install test dependencies
 
@@ -134,13 +135,20 @@ The production-dependency audit exports a temporary `requirements-audit.txt` for
 `pip-audit` only. It is git-ignored, never committed, and never authoritative:
 `pyproject.toml` and `uv.lock` remain the sole Python dependency manifest.
 
-### Reuse by future release automation
+### Native packaging validation
 
-`ci.yml` is `workflow_call`-able. When release automation is added, its
-publishing jobs must invoke this workflow for the exact commit/tag being
-released (`uses: ./.github/workflows/ci.yml`) and depend on its success before
-publishing. Verifying a release only *after* it is published does not satisfy
-this gate.
+[`.github/workflows/package.yml`](../.github/workflows/package.yml) runs for
+packaging-related pull requests and manual dispatches. It builds the Linux
+`.deb` on Ubuntu 24.04 and the unsigned Windows x64 NSIS installer on a native
+Windows runner, generates checksums, and uploads short-lived workflow artifacts.
+The Windows job also installs the package silently, confirms the managed backend
+remains available, closes the app, verifies process cleanup, and uninstalls it.
+Diagnostic logs are uploaded even when the smoke test fails.
+
+This workflow does not publish GitHub Releases. Release automation in #190 can
+reuse the native build interface, but must run `ci.yml` for the exact candidate
+commit and depend on it before publishing. Post-publication verification does
+not replace that gate.
 
 ## Test fixtures
 
@@ -198,7 +206,7 @@ clinical recordings, or decrypted credential contents.
 ## Manual QA
 
 Human checks that add value beyond the automated suites are defined in
-[Linux manual QA](manual-qa.md). It provides stable scenario IDs, synthetic and
+[production manual QA](manual-qa.md). It provides stable scenario IDs, synthetic and
 approved legacy-data requirements, release-candidate gates, packaged-install
 checks, and a sanitized failure-reporting template. Automated CI must pass for
 the exact candidate commit before release manual QA begins.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,10 +1,10 @@
 # User guide
 
 > [!NOTE]
-> EEG2BIDS is currently supported for Linux development use only. Production
-> installers and packaged releases are not supported. See the
-> [project status](../README.md#project-status) before relying on the workflow
-> below.
+> Production packages are supported for Ubuntu amd64 and Windows 11 x64. See
+> [installation](installation.md) and the
+> [project status](../README.md#project-status) for the current support and
+> distribution details.
 
 EEG2BIDS converts one continuous EEG or stereo-iEEG recording into BIDS. Back
 up the source data before conversion.


### PR DESCRIPTION
## Summary

- update project status and packaging instructions for supported Ubuntu and Windows 11 artifacts
- add Windows installation, upgrade, uninstall, SmartScreen, user-data, and diagnostic guidance
- document native packaging CI and its relationship to future release automation in #190
- refresh development, testing, dependency, and user guidance
- convert the Linux packaging design from a draft into an implementation record and record resolved Windows lifecycle decisions

## Verification

- `uvx codespell README.md docs`
- `git diff --check`
- searched maintained docs for stale Linux-only and pending-Windows language
