### PR TITLE
Add immutable release candidate publishing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@
 name: Package
 
 on:
+  workflow_call:
   workflow_dispatch:
   pull_request:
     paths:
@@ -30,14 +31,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: npm
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
 
@@ -53,15 +54,15 @@ jobs:
       - name: Generate checksum
         run: |
           cd dist/electron
-          sha256sum *.deb > SHA256SUMS
+          sha256sum -- *.deb > SHA256SUMS-linux-x64
 
       - name: Upload Linux candidate
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: eeg2bids-linux-x64-${{ github.sha }}
           path: |
             dist/electron/*.deb
-            dist/electron/SHA256SUMS
+            dist/electron/SHA256SUMS-linux-x64
           if-no-files-found: error
           retention-days: 14
 
@@ -70,14 +71,14 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: npm
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
 
@@ -156,7 +157,7 @@ jobs:
 
       - name: Upload packaged application logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: eeg2bids-windows-smoke-logs-${{ github.sha }}
           path: test-results/packaged-windows/
@@ -171,14 +172,14 @@ jobs:
             throw "Expected exactly one NSIS installer, found $($installer.Count)"
           }
           $hash = (Get-FileHash $installer.FullName -Algorithm SHA256).Hash.ToLower()
-          "$hash  $($installer.Name)" | Set-Content dist/electron/SHA256SUMS
+          "$hash  $($installer.Name)" | Set-Content dist/electron/SHA256SUMS-windows-x64
 
       - name: Upload Windows candidate
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: eeg2bids-windows-x64-${{ github.sha }}
           path: |
             dist/electron/*-setup.exe
-            dist/electron/SHA256SUMS
+            dist/electron/SHA256SUMS-windows-x64
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,103 @@
+# Build and publish immutable Linux and unsigned Windows release candidates.
+# Final releases are promoted separately after maintainer QA; this workflow
+# never publishes a production release.
+name: Release candidate
+
+on:
+  push:
+    tags:
+      - 'v*-rc.*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-candidate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate candidate tag
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate tag and package version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc\.([1-9][0-9]*)$ ]]; then
+            echo "Expected an immutable release-candidate tag such as v3.0.0-rc.1" >&2
+            exit 1
+          fi
+          package_version="$(node -p "require('./package.json').version")"
+          if [[ "$package_version" != "${BASH_REMATCH[1]}" ]]; then
+            echo "Tag version ${BASH_REMATCH[1]} does not match package.json version $package_version" >&2
+            exit 1
+          fi
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists and will not be replaced" >&2
+            exit 1
+          fi
+
+  ci:
+    name: Exact-tag test suite
+    needs: validate
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
+  package:
+    name: Native packages
+    needs: validate
+    uses: ./.github/workflows/package.yml
+    permissions:
+      contents: read
+
+  publish:
+    name: Publish GitHub prerelease
+    needs: [ci, package]
+    runs-on: ubuntu-24.04
+    environment: release-candidate
+    permissions:
+      contents: write
+    steps:
+      - name: Download Linux candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: eeg2bids-linux-x64-${{ github.sha }}
+          path: release-assets/linux
+
+      - name: Download Windows candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: eeg2bids-windows-x64-${{ github.sha }}
+          path: release-assets/windows
+
+      - name: Record source provenance
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          cat > release-assets/SOURCE.txt <<EOF
+          tag=$TAG
+          commit=$GITHUB_SHA
+          repository=$GITHUB_REPOSITORY
+          workflow_run=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          windows_signing=unsigned
+          EOF
+
+      - name: Publish immutable prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(find release-assets -type f -print | sort)
+          gh release create "$TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --prerelease \
+            --title "EEG2BIDS ${TAG#v}" \
+            --notes "Automated release candidate for manual QA. The Windows installer is unsigned. Do not promote this candidate unless its recorded checksums pass QA."

--- a/README.md
+++ b/README.md
@@ -199,8 +199,10 @@ freeze step alone is `npm run freeze:backend`, using
 
 The `Package` GitHub Actions workflow builds both platforms natively, smoke
 tests the installed Windows application and managed backend, generates
-`SHA256SUMS`, and uploads workflow artifacts. It does not publish a GitHub
-Release; coordinated candidate publication and promotion remain in #190.
+platform-specific SHA-256 files, and uploads workflow artifacts. Immutable RC
+tags invoke that workflow and publish a GitHub prerelease for manual QA; see the
+[release-candidate guide](docs/releasing.md). Final promotion remains a separate,
+protected manual operation.
 
 See the [installation guide](docs/installation.md), the
 [Windows packaging guide](docs/windows-packaging.md), and the historical

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,52 @@
+# Release candidates
+
+EEG2BIDS releases use immutable release candidates so maintainers can manually
+qualify the exact Linux and Windows files that may later become a final release.
+macOS is tracked separately in issue #189. Windows installers are currently
+unsigned and may trigger a SmartScreen warning.
+
+## Create a candidate
+
+1. Set `package.json` to the intended final version, without an RC suffix (for
+   example, `3.0.0`), update `package-lock.json`, and merge that change to the
+   commit to be released.
+2. Create a new annotated RC tag on that commit. Never move or reuse an RC tag:
+
+   ```bash
+   git tag -a v3.0.0-rc.1 -m "EEG2BIDS 3.0.0 RC 1"
+   git push origin v3.0.0-rc.1
+   ```
+
+3. The release-candidate workflow runs the exact-tag test suite and native
+   Linux/Windows package jobs. If all jobs pass, it creates a GitHub prerelease
+   containing the `.deb`, unsigned Windows installer, platform-specific SHA-256
+   files, and `SOURCE.txt` provenance.
+
+The tag must match `v<package-version>-rc.<positive-number>`. The workflow
+refuses a tag whose final version differs from `package.json`, or one for which
+a GitHub Release already exists.
+
+## Qualify a candidate
+
+Download artifacts from the GitHub prerelease, verify the platform-specific
+checksums, and perform the scenarios in [manual-qa.md](manual-qa.md). Record the
+RC tag, full commit SHA, workflow run, artifact names and checksums, supported
+environment, tester, date, and results.
+
+If QA fails, leave the prerelease and tag intact for traceability. Merge fixes
+and create the next tag (`v3.0.0-rc.2`, for example). Never replace an asset or
+force-push a candidate tag.
+
+Final promotion is a separate, protected manual operation. It must copy the
+qualified prerelease assets byte-for-byte rather than rebuilding them. Until
+that workflow is added, do not treat the RC workflow as authorization to publish
+a final production release.
+
+## Troubleshooting
+
+The Package workflow can be run manually without publishing a GitHub Release.
+Its Linux and Windows artifacts are retained for 14 days. Candidate prerelease
+assets remain attached to the GitHub prerelease for QA and traceability.
+Build and smoke-test failures retain the same diagnostic artifacts described in
+[linux-packaging-verification.md](linux-packaging-verification.md) and
+[windows-packaging.md](windows-packaging.md).


### PR DESCRIPTION
Closes the release-candidate portion of #190.

## Summary

- make native Linux/Windows packaging callable from release automation
- publish immutable `vX.Y.Z-rc.N` GitHub prereleases only after exact-tag CI and packaging succeed
- attach platform-specific checksums and source/workflow provenance
- document candidate creation, rejection, and manual QA
- pin actions touched by the packaging/release path to immutable commits

Final production promotion remains separate and will require protected maintainer approval without rebuilding the qualified assets.

## Validation

- `actionlint .github/workflows/package.yml .github/workflows/release-candidate.yml`
- `uv run --frozen pytest -q` (79 passed)
- `npm run lint` could not run in the existing local install because ESLint/Ajv initialization fails; CI installs from the lockfile with `npm ci`
