### PR TITLE
Add protected release candidate promotion

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,115 @@
+# Promote a manually qualified RC without rebuilding its artifacts. The
+# production-release environment must require maintainer approval. This creates
+# a draft final release so maintainers retain control of notes and publication.
+name: Promote release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: Qualified immutable RC tag (for example v3.0.0-rc.1)
+        required: true
+        type: string
+      final_tag:
+        description: Final version tag to create (for example v3.0.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Create draft final release
+    runs-on: ubuntu-24.04
+    environment: production-release
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RC_TAG: ${{ inputs.rc_tag }}
+      FINAL_TAG: ${{ inputs.final_tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate release selection
+        run: |
+          set -euo pipefail
+          if [[ ! "$RC_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc\.([1-9][0-9]*)$ ]]; then
+            echo "Invalid RC tag: $RC_TAG" >&2
+            exit 1
+          fi
+          rc_version="${BASH_REMATCH[1]}"
+          if [[ "$FINAL_TAG" != "v$rc_version" ]]; then
+            echo "Final tag $FINAL_TAG does not match RC version $rc_version" >&2
+            exit 1
+          fi
+          git rev-parse --verify --quiet "refs/tags/$RC_TAG" >/dev/null || {
+            echo "RC tag does not exist: $RC_TAG" >&2
+            exit 1
+          }
+          if git rev-parse --verify --quiet "refs/tags/$FINAL_TAG" >/dev/null; then
+            echo "Final tag already exists: $FINAL_TAG" >&2
+            exit 1
+          fi
+          if ! gh release view "$RC_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,isPrerelease \
+            --jq 'select(.isDraft == false and .isPrerelease == true)' \
+            | grep -q .; then
+            echo "$RC_TAG is not a published GitHub prerelease" >&2
+            exit 1
+          fi
+          if gh release view "$FINAL_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Final release already exists: $FINAL_TAG" >&2
+            exit 1
+          fi
+
+      - name: Download qualified candidate assets
+        run: |
+          set -euo pipefail
+          mkdir release-assets
+          gh release download "$RC_TAG" --repo "$GITHUB_REPOSITORY" \
+            --dir release-assets
+
+      - name: Verify candidate assets and provenance
+        run: |
+          set -euo pipefail
+          cd release-assets
+          shopt -s nullglob
+          debs=(*.deb)
+          installers=(*-setup.exe)
+          if (( ${#debs[@]} != 1 || ${#installers[@]} != 1 )); then
+            echo "Expected exactly one Linux package and one Windows installer" >&2
+            printf 'Downloaded: %s\n' * >&2
+            exit 1
+          fi
+          required=(SHA256SUMS-linux-x64 SHA256SUMS-windows-x64 SOURCE.txt)
+          for file in "${required[@]}"; do
+            [[ -f "$file" ]] || { echo "Missing candidate asset: $file" >&2; exit 1; }
+          done
+          sha256sum --check SHA256SUMS-linux-x64
+          sha256sum --check SHA256SUMS-windows-x64
+
+          rc_commit="$(git -C .. rev-parse "refs/tags/$RC_TAG^{}")"
+          grep -Fx "tag=$RC_TAG" SOURCE.txt
+          grep -Fx "commit=$rc_commit" SOURCE.txt
+          grep -Fx 'windows_signing=unsigned' SOURCE.txt
+          printf '%s\n' "$rc_commit" > ../rc-commit.txt
+
+      - name: Create draft final release from exact RC assets
+        run: |
+          set -euo pipefail
+          rc_commit="$(cat rc-commit.txt)"
+          mapfile -t assets < <(find release-assets -maxdepth 1 -type f -print | sort)
+          gh release create "$FINAL_TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$rc_commit" \
+            --draft \
+            --title "EEG2BIDS ${FINAL_TAG#v}" \
+            --notes "Promoted byte-for-byte from $RC_TAG after manual QA. The Windows installer is unsigned. Edit these notes before publishing this draft release."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,10 +37,33 @@ If QA fails, leave the prerelease and tag intact for traceability. Merge fixes
 and create the next tag (`v3.0.0-rc.2`, for example). Never replace an asset or
 force-push a candidate tag.
 
-Final promotion is a separate, protected manual operation. It must copy the
-qualified prerelease assets byte-for-byte rather than rebuilding them. Until
-that workflow is added, do not treat the RC workflow as authorization to publish
-a final production release.
+## Promote a qualified candidate
+
+Before the first production release, configure the `production-release` GitHub
+Actions environment with required maintainer reviewers. Restrict deployment to
+the default branch where repository settings support that policy. The workflow's
+environment gate is the release authorization boundary; do not run it without
+review protection configured.
+
+1. Open **Actions → Promote release candidate → Run workflow** on the default
+   branch.
+2. Enter the qualified RC tag and matching final tag (for example,
+   `v3.0.0-rc.2` and `v3.0.0`).
+3. A maintainer other than the initiator reviews the recorded QA evidence and
+   approves the `production-release` environment deployment.
+4. The workflow verifies the prerelease, checks both artifact hashes and its
+   source provenance, creates the final tag at the RC commit, and copies every
+   RC asset without rebuilding.
+5. Open the resulting **draft** GitHub Release, write or edit the release notes,
+   verify the tag and attached assets, and click **Publish release**.
+6. Download the published assets and perform a post-publication checksum check.
+
+The workflow refuses mismatched versions, a non-prerelease source, or an existing
+final tag/release. If it fails before creating the draft, correct the input or
+workflow problem and rerun it. If asset upload fails after GitHub has created the
+final tag or draft, do not publish or rerun blindly: inspect the draft, compare
+its assets with the RC, and remove the incomplete draft and final tag before an
+authorized retry. Never rebuild or substitute assets during cleanup.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Continues #190 after #208.

## Summary

- add a manually dispatched production promotion workflow
- gate promotion on the `production-release` GitHub environment
- validate matching RC/final versions and reject existing final tags/releases
- verify Linux and Windows checksums plus recorded source provenance
- copy the qualified RC assets without rebuilding
- create a draft final release so maintainers retain control of release notes and publication
- document environment setup, approval, publication, verification, and failed-promotion cleanup

## Repository setup required

Before using this workflow, configure the `production-release` environment with required maintainer reviewers. The environment approval is the production authorization boundary.

## Validation

- `actionlint .github/workflows/promote-release.yml`
- `git diff --check`
