### PR TITLE
Prepare version 3.0.0 release candidate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eeg2bids",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eeg2bids",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",
         "papaparse": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eeg2bids",
   "description": "EEG/iEEG to BIDS format Wizard",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "desktopName": "eeg2bids.desktop",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eeg2bids"
-version = "3.0.0b1"
+version = "3.0.0"
 description = "EEG2BIDS Wizard backend: de-identifies EDF data and converts EEG/iEEG recordings to BIDS."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -231,7 +231,7 @@ wheels = [
 
 [[package]]
 name = "eeg2bids"
-version = "3.0.0b1"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "bids-validator" },


### PR DESCRIPTION
Continues #190 by preparing consistent final-version metadata for `v3.0.0-rc.1` qualification.

The RC suffix belongs to the immutable Git tag, while the packaged npm and Python metadata use the intended final version so a qualified candidate can be promoted byte-for-byte.

## Changes

- set npm package metadata to `3.0.0`
- set Python project metadata to `3.0.0`
- update both authoritative lockfiles

## Validation

- `npm ci --ignore-scripts`
- `npm run build`
- `uv lock --check`
- `uv run --frozen pytest -q` (79 passed)
