### PR TITLE
Prevent tagged package builds from publishing implicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "test:unit": "vitest run",
     "test:electron": "npm run build && playwright test",
     "freeze:backend": "uv run --frozen --group packaging pyinstaller --noconfirm --distpath dist --workpath dist/.pyinstaller-work tools/eeg2bids-backend.spec",
-    "dist:dir": "npm run build && npm run freeze:backend && electron-builder --linux dir",
-    "dist:linux": "npm run build && npm run freeze:backend && electron-builder --linux deb",
-    "dist:windows": "npm run build && npm run freeze:backend && electron-builder --win nsis --x64"
+    "dist:dir": "npm run build && npm run freeze:backend && electron-builder --linux dir --publish never",
+    "dist:linux": "npm run build && npm run freeze:backend && electron-builder --linux deb --publish never",
+    "dist:windows": "npm run build && npm run freeze:backend && electron-builder --win nsis --x64 --publish never"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css,md}": [


### PR DESCRIPTION
Fixes the packaging failure discovered by `v3.0.0-rc.1` in #190.

Electron-builder detects Git tags and defaults to implicit GitHub publishing. The native package jobs intentionally have read-only permissions and publication belongs exclusively to `release-candidate.yml`, so electron-builder failed after creating the Linux `.deb` because no publishing token was available.

This passes `--publish never` to every local packaging command. The release-candidate workflow will continue to publish the verified, coordinated artifacts explicitly after both packages and the exact-tag CI suite pass.

`v3.0.0-rc.1` remains immutable and failed. After this merges, the next candidate will be `v3.0.0-rc.2`.

## Validation

- `npx electron-builder --linux dir --publish never --help`
- `git diff --check`
